### PR TITLE
Compare Two Dacpacs and identify the schema differences

### DIFF
--- a/DacFxStronglyTypedModel/DacFxStronglyTypedModel.csproj
+++ b/DacFxStronglyTypedModel/DacFxStronglyTypedModel.csproj
@@ -31,20 +31,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Schema.Sql">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Tools.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Utilities">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac.Extensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Types.dll</HintPath>

--- a/RuleSamples/RuleSamples.csproj
+++ b/RuleSamples/RuleSamples.csproj
@@ -31,20 +31,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Schema.Sql">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Tools.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Utilities">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac.Extensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Types.dll</HintPath>

--- a/RuleTests/RuleTests.csproj
+++ b/RuleTests/RuleTests.csproj
@@ -36,20 +36,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Schema.Sql">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Tools.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Utilities">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac.Extensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Types.dll</HintPath>

--- a/SampleConsoleApp/ModelCompareDacs.cs
+++ b/SampleConsoleApp/ModelCompareDacs.cs
@@ -17,6 +17,13 @@ namespace Public.Dac.Samples.App
         , SourceOnly
         , DestinationOnly
     }
+    /// <summary>
+    /// Basic demo class showing results of comparing Two Dacpacs and also filters the Dacpacs and removes specific schema
+    /// The Output includes:
+    /// Identical SQL objects which exists on both the Dacpacs but have some differences in schema/T-SQL code
+    /// SQL objects which exists on the Source Dacpac only
+    /// SQL objects which exits on the destination Dacpac only
+    /// </summary>
     internal class ModelCompareDacs
     {
         private static string _sourceDacpacPath;
@@ -119,8 +126,6 @@ namespace Public.Dac.Samples.App
 
                     if (!destt.GetScript().Equals(sourcet.GetScript()))
                     {
-                        //save the source script
-                        //save the destination script
                         SaveScriptToFile(sourcet, Outcome.Source);
                         SaveScriptToFile(destt, Outcome.Destination);
                     }
@@ -140,7 +145,6 @@ namespace Public.Dac.Samples.App
 
             foreach (var t in tsqldestobj)
             {
-                Console.WriteLine($"{t.Name}");
                 SaveScriptToFile(t, Outcome.DestinationOnly);
             }
 

--- a/SampleConsoleApp/ModelCompareDacs.cs
+++ b/SampleConsoleApp/ModelCompareDacs.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.Dac;
+using Microsoft.SqlServer.Dac.Model;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace Public.Dac.Samples.App
+{
+    internal enum Outcome
+    {
+        Source
+        , Destination
+        , SourceOnly
+        , DestinationOnly
+    }
+    internal class ModelCompareDacs
+    {
+        private static string _sourceDacpacPath;
+        private static string _destinationDacPacPath;
+        private static string _ModelCompareDacsPath = "ModelCompareDacs";
+        private static string _compareResultsPath = "ModelCompareResults";
+
+        private static DisposableList _trash = new DisposableList();
+
+        private static readonly string[] _testSourceScripts = new string[]
+        {
+            "CREATE SCHEMA [log]",
+            "CREATE TABLE [log].[l1] (l1 INT NOT NULL PRIMARY KEY)",
+            "CREATE VIEW [log].[v1] AS SELECT l1 FROM [log].[l1]",
+
+            "CREATE TABLE [dbo].[t2] (c2 INT NOT NULL)",
+            "CREATE UNIQUE CLUSTERED INDEX Idx1 ON [dbo].[t2] (c2)",
+            "CREATE VIEW [dbo].[v2] AS SELECT c2 FROM [dbo].[t2]",
+            "CREATE TABLE [dbo].[t3] (c3 INT NOT NULL PRIMARY KEY)",
+            "CREATE TABLE [dbo].[t5] (c5 INT NOT NULL PRIMARY KEY)"
+        };
+
+        private static readonly string[] _testDestinationScripts = new string[]
+        {
+            "CREATE SCHEMA [log]",
+            "CREATE TABLE [log].[l1] (l1 INT NOT NULL PRIMARY KEY)",
+            "CREATE VIEW [log].[v1] AS SELECT l1 FROM [log].[l1]",
+
+            "CREATE TABLE [dbo].[t2] (c2 INT NOT NULL)",
+            "CREATE VIEW [dbo].[v2] AS SELECT c2 FROM [dbo].[t2]",
+            "CREATE TABLE [dbo].[t4] (c4 INT NOT NULL PRIMARY KEY)",
+            "CREATE TABLE [dbo].[t5] (c5 VARCHAR(1) NOT NULL PRIMARY KEY)"
+        };
+
+        private static ModelTypeClass[] modelSchemaName = new ModelTypeClass[]
+            {
+             ModelSchema.View
+            ,ModelSchema.TableValuedFunction
+            ,ModelSchema.ScalarFunction
+            ,ModelSchema.Index
+            ,ModelSchema.DmlTrigger
+            ,ModelSchema.PartitionFunction
+            ,ModelSchema.PartitionScheme
+            ,ModelSchema.Schema
+            ,ModelSchema.Procedure
+            ,ModelSchema.Table
+            ,ModelSchema.TableType
+            };
+
+        public static void Run()
+        {
+            Directory.CreateDirectory(GetTestDir(_ModelCompareDacsPath));
+            Directory.CreateDirectory(GetTestDir(_compareResultsPath));
+            _sourceDacpacPath = GetTestFilePath(_ModelCompareDacsPath, "sourceDatabase.dacpac");
+            DacPackageExtensions.BuildPackage(_sourceDacpacPath, CreateTestModel(_testSourceScripts), new PackageMetadata());
+            _destinationDacPacPath = GetTestFilePath(_ModelCompareDacsPath, "destinationDatabase.dacpac");
+            DacPackageExtensions.BuildPackage(_destinationDacPacPath, CreateTestModel(_testDestinationScripts), new PackageMetadata());
+
+            using (TSqlModel sourcemodel = new TSqlModel(_sourceDacpacPath),
+                             destmodel = new TSqlModel(_destinationDacPacPath))
+            {
+
+                // Filtering to exclude log schema
+                var schemaFilter = new SchemaBasedFilter("log");
+                ModelFilterer modelFilterer = new ModelFilterer(schemaFilter);
+                TSqlModel smodel = modelFilterer.CreateFilteredModel(sourcemodel);
+                TSqlModel dmodel = modelFilterer.CreateFilteredModel(destmodel);
+
+                CompareTSqlModels(smodel, dmodel);
+            }
+        }
+
+        private static void SaveScriptToFile(TSqlObject scriptTsqlObject, Outcome outcomeName)
+        {
+            string filePath = Path.Combine(Environment.CurrentDirectory, _compareResultsPath, $"{scriptTsqlObject.Name}_{outcomeName}.txt");
+            using (StreamWriter writer = new StreamWriter(filePath))
+            {
+                writer.WriteLine(scriptTsqlObject.GetScript());
+            }
+
+        }
+
+        private static void CompareTSqlModels(TSqlModel sourcemodel, TSqlModel destModel)
+        {
+            List<TSqlObject> destCollection = new List<TSqlObject>();
+
+            var sourceTables = sourcemodel.GetObjects(DacQueryScopes.UserDefined, modelSchemaName).ToList();
+            var destObjects = destModel.GetObjects(DacQueryScopes.UserDefined, modelSchemaName).ToList();
+
+            foreach (var sourcet in sourceTables)
+            {
+                var dbObjectParts = sourcet.Name.Parts;
+
+                var destt = destModel.GetObjects(sourcet.ObjectType, new ObjectIdentifier(dbObjectParts), DacQueryScopes.UserDefined).FirstOrDefault();
+
+                if (destt != null)
+                {
+
+                    bool flag = destt.GetScript().Equals(sourcet.GetScript());
+
+                    if (!destt.GetScript().Equals(sourcet.GetScript()))
+                    {
+                        //save the source script
+                        //save the destination script
+                        SaveScriptToFile(sourcet, Outcome.Source);
+                        SaveScriptToFile(destt, Outcome.Destination);
+                    }
+
+                    destCollection.Add(destt);
+
+                }
+                else
+                {
+                    SaveScriptToFile(sourcet, Outcome.SourceOnly);
+                }
+
+            }
+
+            var tsqldestobj = destObjects.Except(destCollection);
+
+
+            foreach (var t in tsqldestobj)
+            {
+                Console.WriteLine($"{t.Name}");
+                SaveScriptToFile(t, Outcome.DestinationOnly);
+            }
+
+        }
+
+        private static TSqlModel CreateTestModel(params string[] Tsqlscripts)
+        {
+            var scripts = Tsqlscripts;
+            TSqlModel model = _trash.Add(new TSqlModel(SqlServerVersion.Sql110, new TSqlModelOptions()));
+            AddScriptsToModel(model, scripts);
+            return model;
+        }
+        private static void AddScriptsToModel(TSqlModel model, IEnumerable<string> scripts)
+        {
+            foreach (string script in scripts)
+            {
+                model.AddObjects(script);
+            }
+        }
+
+        private static string GetTestDir(string directoryName)
+        {
+
+            return Path.Combine(Environment.CurrentDirectory, directoryName);
+        }
+
+        private static string GetTestFilePath(string dirName, string fileName)
+        {
+            return Path.Combine(GetTestDir(dirName), fileName);
+        }
+        public static void CleanupTest()
+        {
+            _trash.Dispose();
+        }
+    }
+}

--- a/SampleConsoleApp/ModelCompareDacs.cs
+++ b/SampleConsoleApp/ModelCompareDacs.cs
@@ -19,10 +19,10 @@ namespace Public.Dac.Samples.App
     }
     /// <summary>
     /// Basic demo class showing results of comparing Two Dacpacs and also filters the Dacpacs and removes specific schema
-    /// The Output includes:
-    /// Identical SQL objects which exists on both the Dacpacs but have some differences in schema/T-SQL code
+    /// The output includes:
+    /// Any identical SQL objects which exists on both the Dacpacs but have some differences in schema/T-SQL code
     /// SQL objects which exists on the Source Dacpac only
-    /// SQL objects which exits on the destination Dacpac only
+    /// SQL objects which exists on the Destination Dacpac only
     /// </summary>
     internal class ModelCompareDacs
     {

--- a/SampleConsoleApp/Program.cs
+++ b/SampleConsoleApp/Program.cs
@@ -36,7 +36,8 @@ namespace Public.Dac.Samples.App
             RunEndToEnd,
             FilterModel,
             RunCodeAnalysis,
-            ValidateQuerySemantically
+            ValidateQuerySemantically,
+            CompareDacs
         }
 
         static void Main(string[] args)
@@ -65,8 +66,12 @@ Current actions:
                 case Behavior.ValidateQuerySemantically:
                     RunValidateQuerySemanticallyExample.Run();
                     break;
-                    // To test deployment plan-based filtering see the TestFiltering.TestFilterPlanWhenPublishing() unit test
+                // To test deployment plan-based filtering see the TestFiltering.TestFilterPlanWhenPublishing() unit test
+                case Behavior.CompareDacs:
+                    ModelCompareDacs.Run();
+                    break;
             }
+
 
             Console.WriteLine("Press any key to finish");
             Console.ReadKey();
@@ -92,6 +97,10 @@ Current actions:
                 if (MatchesBehavior(args[0], Behavior.ValidateQuerySemantically))
                 {
                     behavior = Behavior.ValidateQuerySemantically;
+                }
+                if (MatchesBehavior(args[0], Behavior.CompareDacs))
+                {
+                    behavior = Behavior.CompareDacs;
                 }
             }
             return behavior;

--- a/SampleConsoleApp/SampleConsoleApp.csproj
+++ b/SampleConsoleApp/SampleConsoleApp.csproj
@@ -33,20 +33,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Schema.Sql">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Tools.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Utilities">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac.Extensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Types.dll</HintPath>
@@ -61,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ModelCompareDacs.cs" />
     <Compile Include="ModelEndToEnd.cs" />
     <Compile Include="ModelFilterExample.cs" />
     <Compile Include="Program.cs" />

--- a/SampleTests/SampleTests.csproj
+++ b/SampleTests/SampleTests.csproj
@@ -36,20 +36,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Schema.Sql">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Tools.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Utilities">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac.Extensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Types.dll</HintPath>

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -31,20 +31,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Schema.Sql">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Tools.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Utilities">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac.Extensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Types.dll</HintPath>

--- a/TestUtils/TestUtils.csproj
+++ b/TestUtils/TestUtils.csproj
@@ -31,20 +31,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Schema.Sql">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Tools.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.Data.Tools.Utilities.dll</HintPath>
+    <Reference Include="Microsoft.Data.Tools.Utilities">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.Data.Tools.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.Dac.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.Dac.Extensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.Dac.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
+      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft SQL Server\150\DAC\bin\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=14.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.140.3745.1\lib\net46\Microsoft.SqlServer.Types.dll</HintPath>


### PR DESCRIPTION
Updated the examples in DacExtensions to include a demo class showing results of comparing Two Dacpacs and also filters the Dacpacs by removing specific schema in it.
The output includes:

- Any Identical SQL objects which exists on both the Dacpacs but have some differences in schema/T-SQL code
- SQL objects which exists on the Source Dacpac only
- SQL objects which exists on the Destination Dacpac only